### PR TITLE
Added new credits tab

### DIFF
--- a/mods/kknd1/CREDITS
+++ b/mods/kknd1/CREDITS
@@ -8,6 +8,15 @@ Custom artwork contributors:
 	* Embodied dissapointment
 	* Glenn Bermingham (Packer)
 
+Mappers:
+	* Pawel Dzierzanowski (Dzierzan)
+	* Zasso
+	* Xopek
+	* TimoxaZlobniy
+	* MrZuerg
+	* MustaphaTR
+
+
 Special thanks:
 	* Moritz Ernst Jacob (Hallfiry)
     * Zimmermann Gyula (Graion Dilach)

--- a/mods/kknd1/CREDITS
+++ b/mods/kknd1/CREDITS
@@ -1,0 +1,15 @@
+The main OpenRA KKND developers are:
+    * Andre Mohren (IceReaper)
+    * Pawel Dzierzanowski (Dzierzan)
+
+Custom artwork contributors:
+	* Pawel Dzierzanowski (Dzierzan)
+	* JMSower
+	* Embodied dissapointment
+	* Glenn Bermingham (Packer)
+
+Special thanks:
+	* Moritz Ernst Jacob (Hallfiry)
+    * Zimmermann Gyula (Graion Dilach)
+    * Martin Lang (Seras)
+    * Peter Böttger (DeZomb)

--- a/mods/kknd1/core/mod.yaml
+++ b/mods/kknd1/core/mod.yaml
@@ -48,3 +48,7 @@ Notifications:
 
 Cursors:
 	kknd1|core/cursors.yaml
+
+ModCredits:
+	ModCreditsFile: kknd1|CREDITS
+	ModTabTitle: OpenRA KKND


### PR DESCRIPTION
I hope I didn't forget about anyone. More credits tabs could be added in the future. Anyway "OpenRA KKND" name is a subject to be changed later, as soon as a new name is chosen for the project.

![image](https://user-images.githubusercontent.com/17529329/109714025-34760400-7ba2-11eb-8a4a-6f977f8bd56a.png)

Although I am not sure about Zimmermann Gyula (Graion Dilach), I mean I vaguely remember he did something for KKND2, I guess it counts.

Closes #95 