### PR TITLE
Check for dotnet in launch scripts

### DIFF
--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -5,7 +5,9 @@
 #  Read the file to see which settings you can override
 
 set -e
-command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires mono."; exit 1; }
+if ! command -v mono >/dev/null 2>&1; then
+	command -v dotnet >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires mono or dotnet."; exit 1; }
+fi
 if command -v python3 >/dev/null 2>&1; then
 	PYTHON="python3"
 else

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 set -e
-command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires mono."; exit 1; }
+if ! command -v mono >/dev/null 2>&1; then
+	command -v dotnet >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires mono or dotnet."; exit 1; }
+fi
 if command -v python3 >/dev/null 2>&1; then
 	PYTHON="python3"
 else

--- a/utility.sh
+++ b/utility.sh
@@ -5,7 +5,9 @@
 
 set -e
 command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires make."; exit 1; }
-command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires mono."; exit 1; }
+if ! command -v mono >/dev/null 2>&1; then
+	command -v dotnet >/dev/null 2>&1 || { echo >&2 "The OpenRA mod SDK requires mono or dotnet."; exit 1; }
+fi
 
 if command -v python3 >/dev/null 2>&1; then
 	PYTHON="python3"


### PR DESCRIPTION
Launch scripts crashed on missing `mono` even if they could use `dotnet`.